### PR TITLE
맞춤법검사기 클라이언트 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,3 +151,37 @@ ss = tokenized.symbols()
 print(ss)
 
 ```
+
+## How to use, spelling corrector
+```python
+from bareunpy import Corrector
+
+# You can get an API-KEY from https://bareun.ai/
+# Please note that you need to sign up and verify your email.
+# 아래에 "https://bareun.ai/"에서 이메일 인증 후 발급받은 API KEY("koba-...")를 입력해주세요. "로그인-내정보 확인"
+API_KEY = "koba-ABCDEFG-1234567-LMNOPQR-7654321"  # <- 본인의 API KEY로 교체(Replace this with your own API KEY)
+
+# Initialize Corrector
+corrector = Corrector(API_KEY)
+
+# Single sentence correction
+response = corrector.correct_error("영수 도 줄기가 얇어서 시들을 것 같은 꽃에물을 주었다.")
+print(f"Original: {response.origin}")
+print(f"Corrected: {response.revised}")
+corrector.print_results(response)
+
+# Multiple sentences correction
+responses = corrector.correct_error_list([
+    "어머니 께서 만들어주신김치찌게가너무맵다며동생이울어버렸다.",
+    "영수 도 줄기가 얇어서 시들을 것 같은 꽃에물을 주었다."
+])
+for res in responses:
+    print(f"Original: {res.origin}")
+    print(f"Corrected: {res.revised}")
+
+corrector.print_results(responses)
+
+# JSON output
+corrector.print_as_json(response)
+
+```

--- a/bareunpy/__init__.py
+++ b/bareunpy/__init__.py
@@ -55,5 +55,5 @@ from bareunpy._custom_dict import CustomDict
 from bareunpy._custom_dict_client import CustomDictionaryServiceClient
 from bareunpy._lang_service_client import BareunLanguageServiceClient
 
-version = "1.6.4"
+version = "1.6.5"
 bareun_version = "1.8.0"

--- a/bareunpy/_corrector.py
+++ b/bareunpy/_corrector.py
@@ -1,0 +1,202 @@
+import grpc
+import json
+from sys import stdout
+from typing import IO, List, Union
+from google.protobuf.json_format import MessageToDict
+
+import bareun.revision_service_pb2 as pb
+import bareun.lang_common_pb2 as lpb
+from ._revision_service_client import BareunRevisionServiceClient
+
+MAX_MESSAGE_LENGTH = 100 * 1024 * 1024
+
+
+class Corrector:
+    """
+    Corrector는 맞춤법 교정 서비스를 제공하는 클래스입니다.
+
+    .. code-block:: python
+        :emphasize-lines: 1
+        >>> from bareunpy import Corrector
+        >>> corrector = Corrector(apikey="koba-YOURKEY")
+        
+        # 단일 문장 교정
+        >>> response = corrector.correct_error("영수 도 줄기가 얇어서 시들을 것 같은 꽃에물을 주었더니 고은 꽃이 피었다.")
+        >>> corrector.print_results(response)
+            === 맞춤법 검사 결과 1===
+            원문: 영수 도 줄기가 얇어서 시들을 것 같은 꽃에물을 주었더니 고은 꽃이 피었다.
+            교정문: 영수도 줄기가 얇아서 시들 것 같은 꽃에 물을 주었더니 고운 꽃이 피었다.
+
+            === 교정된 문장들 ===
+            [1] 원문: 영수 도 줄기가 얇어서 시들을 것 같은 꽃에물을 주었더니 고은 꽃이 피었다.
+                교정문: 영수도 줄기가 얇아서 시들 것 같은 꽃에 물을 주었더니 고운 꽃이 피었다.
+                === 수정 블록 ===
+                1-1 원문: 영수 도
+                    교정문: 영수도
+                    수정 세부사항:
+                    - 조사는 그 앞말에 붙여 쓴다. (일반) 
+                1-2 ...
+
+        # 여러 문장 교정
+        >>> responses = corrector.correct_error_list([
+        ...     "어머니께서 만들어주신김치찌게가너무맵다며동생이울어버렸다.",
+        ...     "영수 도 줄기가 얇어서 시들을 것 같은 꽃에물을 주었더니 고은 꽃이 피었다."
+        ... ])
+        >>> for res in responses:
+        ...     print(res.revised)
+
+    :param apikey: str. Bareun API 키
+    :param host: str. gRPC 서버 호스트, 로컬에 바른 서버 설치시 'localhost' 입력 (기본값: nlp.bareun.ai)
+    :param port: int. gRPC 서버 포트 (기본값: 5656)
+    """
+
+    def __init__(self, apikey: str, host: str = "", port: int = 5656):
+        """
+        Corrector 초기화
+
+        Args:
+            apikey (str): API 키
+            host (str): gRPC 서버 호스트
+            port (int): gRPC 서버 포트
+        """
+        if host:
+            host = host.strip()
+        if apikey:
+            apikey = apikey.strip()
+        if host == "" or host is None:
+            self.host = 'nlp.bareun.ai'
+        else:
+            self.host = host 
+        
+        if port is not None:
+            self.port = port
+        else:
+            self.port = 5656
+
+        self.channel = grpc.insecure_channel(
+            f"{self.host}:{self.port}",
+            options=[
+                ('grpc.max_send_message_length', MAX_MESSAGE_LENGTH),
+                ('grpc.max_receive_message_length', MAX_MESSAGE_LENGTH),
+            ]
+        )
+        self.client = BareunRevisionServiceClient(self.channel, apikey, self.host, self.port)
+
+    def correct_error(self, content: str, auto_split: bool = True, custom_domain: str = "") -> pb.CorrectErrorResponse:
+        """
+        맞춤법 교정 요청
+
+        Args:
+            content (str): 교정을 요청할 문장
+            auto_split (bool): 문장 자동 분리 여부
+            custom_domain (str): 커스텀 도메인 정보
+
+        Returns:
+            pb.CorrectErrorResponse: 교정 결과
+        """
+        request = pb.CorrectErrorRequest(
+            document=lpb.Document(content=content, language="ko_KR"),
+            encoding_type=lpb.EncodingType.UTF32,
+            auto_split_sentence=auto_split
+        )
+        if custom_domain:
+            request.custom_domain = custom_domain
+
+        return self.client.correct_error(request)
+
+    def correct_error_list(self, contents: List[str], auto_split: bool = False, custom_domain: str = "") -> List[pb.CorrectErrorResponse]:
+        """
+        여러 문장에 대한 맞춤법 교정 요청
+
+        Args:
+            contents (List[str]): 교정을 요청할 문장 리스트
+            auto_split (bool): 문장 자동 분리 여부
+            custom_domain (str): 커스텀 도메인 정보
+
+        Returns:
+            List[pb.CorrectErrorResponse]: 각 문장에 대한 pb.CorrectErrorResponse 객체의 리스트
+        """
+        results = []
+        for content in contents:
+            request = pb.CorrectErrorRequest(
+                document=lpb.Document(content=content, language="ko_KR"),
+                encoding_type=lpb.EncodingType.UTF32,
+                auto_split_sentence=auto_split
+            )
+            if custom_domain:
+                request.custom_domain = custom_domain
+            
+            response = self.client.correct_error(request)
+            results.append(response)
+        return results
+
+    def print_results(self, response: Union[pb.CorrectErrorResponse, List[pb.CorrectErrorResponse]], out: IO = stdout) -> None:
+        """
+        교정 결과를 출력
+
+        Args:
+            response (Union[pb.CorrectErrorResponse, List[pb.CorrectErrorResponse]]): 교정 결과 또는 교정 결과의 리스트
+            out (IO): 출력 대상 (기본값: stdout)
+        """
+        # 단일 객체를 리스트로 변환하여 처리
+        if not isinstance(response, list):
+            response = [response]
+
+        for result_index, single_response in enumerate(response, start=1):
+            print(f"=== 맞춤법 검사 결과 {result_index}===", file=out)
+            print(f"원문: {single_response.origin}", file=out)
+            print(f"교정문: {single_response.revised}", file=out)
+
+            if single_response.revised_sentences:
+                print("\n=== 교정된 문장들 ===", file=out)
+                for sentence in single_response.revised_sentences:
+                    print(f"[{result_index}] 원문: {sentence.origin}", file=out)
+                    print(f"    교정문: {sentence.revised}", file=out)
+                    if sentence.revised_blocks:
+                        print("    === 수정 블록 ===", file=out)
+                        for block_index, block in enumerate(sentence.revised_blocks, start=1):
+                            print(f"    {result_index}-{block_index} 원문: {block.origin.content}", file=out)
+                            print(f"        교정문: {block.revised}", file=out)
+                            if block.revisions:
+                                print("        수정 세부사항:", file=out)
+                                for rev in block.revisions:
+                                    print(f"          - {rev.comment} ({rev.category})", file=out)
+
+    def as_json(self, response: Union[pb.CorrectErrorResponse, List[pb.CorrectErrorResponse]]) -> Union[dict, List[dict]]:
+        """
+        교정 결과를 JSON 형식으로 변환
+
+        Args:
+            response (Union[pb.CorrectErrorResponse, List[pb.CorrectErrorResponse]]): 교정 결과 또는 교정 결과의 리스트
+
+        Returns:
+            Union[dict, List[dict]]: JSON 형식으로 변환된 결과
+        """
+        if isinstance(response, list):
+            return [MessageToDict(resp, including_default_value_fields=True, use_integers_for_enums=False) for resp in response]
+        else:
+            return MessageToDict(response, including_default_value_fields=True, use_integers_for_enums=False)
+
+    def as_json_str(self, response: Union[pb.CorrectErrorResponse, List[pb.CorrectErrorResponse]]) -> str:
+        """
+        교정 결과를 JSON 문자열로 변환
+
+        Args:
+            response (Union[pb.CorrectErrorResponse, List[pb.CorrectErrorResponse]]): 교정 결과 또는 교정 결과의 리스트
+
+        Returns:
+            str: JSON 문자열로 변환된 결과
+        """
+        json_data = self.as_json(response)
+        return json.dumps(json_data, ensure_ascii=False, indent=2)
+
+    def print_as_json(self, response: Union[pb.CorrectErrorResponse, List[pb.CorrectErrorResponse]], out: IO = stdout) -> None:
+        """
+        교정 결과를 JSON 형식으로 출력
+
+        Args:
+            response (Union[pb.CorrectErrorResponse, List[pb.CorrectErrorResponse]]): 교정 결과 또는 교정 결과의 리스트
+            out (IO): 출력 대상 (기본값: stdout)
+        """
+        json_data = self.as_json(response)
+        json.dump(json_data, out, ensure_ascii=False, indent=2)

--- a/bareunpy/_lang_service_client.py
+++ b/bareunpy/_lang_service_client.py
@@ -4,6 +4,7 @@ from typing import List
 import bareunpy
 import bareun.language_service_pb2 as pb
 import bareun.language_service_pb2_grpc as ls
+import bareun.lang_common_pb2 as lpb
 
 MAX_MESSAGE_LENGTH = 100 * 1024 * 1024
 
@@ -37,7 +38,10 @@ class BareunLanguageServiceClient:
             message = f'\n입력한 API KEY가 정확한지 확인해 주세요.\n > APIKEY: {self.apikey}\n서버 메시지: {server_message}'
         elif e.code() == grpc.StatusCode.UNAVAILABLE:
             message = f'\n서버에 연결할 수 없습니다. 입력한 서버주소 [{self.host}:{self.port}]가 정확한지 확인해 주세요.\n서버 메시지: {server_message}'
+        elif e.code() == grpc.StatusCode.INVALID_ARGUMENT:
+            message = f'\n잘못된 요청이 서버로 전송되었습니다. 입력 데이터를 확인하세요.\n서버 메시지: {server_message}'
         else:
+            message = f'알 수 없는 오류가 발생했습니다.\n서버 메시지: {server_message}'
             raise e
         raise Exception(message) from e
     
@@ -66,7 +70,7 @@ class BareunLanguageServiceClient:
         # req.document = pb.Document()
         req.document.content = content
         req.document.language = "ko_KR"
-        req.encoding_type = pb.EncodingType.UTF32
+        req.encoding_type = lpb.EncodingType.UTF32
         req.auto_split_sentence = auto_split
         req.auto_spacing = auto_spacing
         req.auto_jointing = auto_jointing
@@ -106,7 +110,7 @@ class BareunLanguageServiceClient:
         req = pb.AnalyzeSyntaxListRequest()
         req.sentences.extend(content)
         req.language = "ko_KR"
-        req.encoding_type = pb.EncodingType.UTF32
+        req.encoding_type = lpb.EncodingType.UTF32
         req.auto_spacing = auto_spacing
         req.auto_jointing = auto_jointing
         if domain:
@@ -142,7 +146,7 @@ class BareunLanguageServiceClient:
         # req.document = pb.Document()
         req.document.content = content
         req.document.language = "ko_KR"
-        req.encoding_type = pb.EncodingType.UTF32
+        req.encoding_type = lpb.EncodingType.UTF32
         req.auto_split_sentence = auto_split
         try:
             res, c = self.stub.Tokenize.with_call(

--- a/bareunpy/_revision_service_client.py
+++ b/bareunpy/_revision_service_client.py
@@ -1,0 +1,64 @@
+import grpc
+import bareun.revision_service_pb2 as pb
+import bareun.revision_service_pb2_grpc as rs_grpc
+
+MAX_MESSAGE_LENGTH = 100 * 1024 * 1024
+
+
+class BareunRevisionServiceClient:
+    """
+    맞춤법 검사를 처리하는 클라이언트
+    """
+
+    def __init__(self, channel, apikey: str, host: str, port: int):
+        """
+        RevisionServiceClient 초기화
+
+        Args:
+            apikey (str): API 키
+            host (str): gRPC 서버 주소
+            port (int): gRPC 서버 포트
+        """
+        self.channel = channel
+        self.apikey = apikey
+        self.host = host
+        self.port = port
+        self.metadata = [
+            ('api-key', self.apikey),
+            ('user-agent', 'bareun-revision-client'),
+        ]
+
+        
+        self.stub = rs_grpc.RevisionServiceStub(self.channel)
+
+    def _handle_grpc_error(self, e: grpc.RpcError):
+        """gRPC 에러를 처리하는 메서드"""
+        server_message = e.details() if e.details() else "서버에서 추가 메시지를 제공하지 않았습니다."
+        if e.code() == grpc.StatusCode.PERMISSION_DENIED:
+            message = f'\n입력한 API KEY가 정확한지 확인해 주세요.\n > APIKEY: {self.apikey}\n서버 메시지: {server_message}'
+        elif e.code() == grpc.StatusCode.UNAVAILABLE:
+            message = f'\n서버에 연결할 수 없습니다. 입력한 서버주소 [{self.host}:{self.port}]를 확인하세요.\n서버 메시지: {server_message}'
+        elif e.code() == grpc.StatusCode.INVALID_ARGUMENT:
+            message = f'\n잘못된 요청이 서버로 전송되었습니다. 입력 데이터를 확인하세요.\n서버 메시지: {server_message}'
+        else:
+            message = f'알 수 없는 오류가 발생했습니다.\n서버 메시지: {server_message}'
+            raise e
+        raise Exception(message) from e
+
+    def correct_error(self, request: pb.CorrectErrorRequest) -> pb.CorrectErrorResponse:
+        """
+        맞춤법 교정을 위한 gRPC 호출
+
+        Args:
+            request (pb.CorrectErrorRequest): gRPC 요청 메시지
+
+        Returns:
+            pb.CorrectErrorResponse: gRPC 응답 메시지
+        """
+        try:
+            response, call = self.stub.CorrectError.with_call(
+                request=request, metadata=self.metadata
+            )
+            return response
+        except grpc.RpcError as e:
+            self._handle_grpc_error(e)

--- a/bareunpy/_tagger.py
+++ b/bareunpy/_tagger.py
@@ -179,7 +179,7 @@ class Tagger:
         if apikey == None or len(apikey) == 0:
             raise ValueError("a apikey must be provided!")
 
-        self.client = BareunLanguageServiceClient(self.channel, apikey, host, port)
+        self.client = BareunLanguageServiceClient(self.channel, apikey, self.host, self.port)
 
         self.domain = domain
         self.custom_dicts = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bareunpy"
-version = "1.6.4"
+version = "1.6.5"
 description = "The bareun python library using grpc"
 authors = ["Gihyun YUN <gih2yun@baikal.ai>"]
 license = "BSD-3-Clause"

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ Operating System :: MacOS
 
 setuptools.setup(
     name="bareunpy",
-    version="1.6.4",
+    version="1.6.5",
     author="Gihyun YUN",
     author_email="gih2yun@baikal.ai",
     description="The bareun python API library",


### PR DESCRIPTION
### 기존 코드 수정

- grpc_error 코드 추가
- tagger에서 init host, port 수정
- lang_common 적용

### 맞춤법 검사기 클라이언트 추가

- _corrector.py: Corrector 클래스에서 맞춤법 관련 기능 실행
- _revision_service_client.py: BareunRevisionServiceClient에서 gRPC 호출


### ReadME 수정

- python code 구현

### version 수정

- 1.6.4 -> 1.6.5


### 실행 출력 예시

```python
from bareunpy._corrector import Corrector
corrector = Corrector(apikey=API_KEY, host=HOST, port=PORT)
response_single = corrector.correct_error(content="영수 도 줄기가 얇어서 시들을 것 같은 꽃에물을 주었더니 고은 꽃이 피었다.", auto_split=False)
corrector.print_results(response_single)

```

```
>>>

=== 맞춤법 검사 결과 1===
원문: 영수 도 줄기가 얇어서 시들을 것 같은 꽃에물을 주었더니 고은 꽃이 피었다.
교정문: 영수도 줄기가 얇아서 시들 것 같은 꽃에 물을 주었더니 고운 꽃이 피었다.

=== 교정된 문장들 ===
[1] 원문: 영수 도 줄기가 얇어서 시들을 것 같은 꽃에물을 주었더니 고은 꽃이 피었다.
    교정문: 영수도 줄기가 얇아서 시들 것 같은 꽃에 물을 주었더니 고운 꽃이 피었다.
    === 수정 블록 ===
    1-1 원문: 영수 도
        교정문: 영수도
        수정 세부사항:
          - 조사는 그 앞말에 붙여 쓴다. (일반) (3)
    1-2 원문: 얇어서
        교정문: 얇아서
        수정 세부사항:
          - 어간의 끝음절 모음이 ‘ㅏ, ㅗ’일 때에는 어미를 ‘- 아’로 적고, 그 밖의 모음일 때에는 ‘- 어’로 적는다. 국어에서는 어간 끝음절의 모음이 ‘ㅏ, ㅑ, ㅗ’일 때는 ‘­-아’ 계열의 어미가 결합하고, ‘ㅐ, ㅓ, ㅔ, ㅕ, ㅚ, ㅜ, ㅟ, ㅡ, ㅢ, ㅣ’ 등일 때는 ‘-­어’ 계열의 어미가 결합한다. 이처럼 어간의 모음에 따라 어미의 모음이 결정되는 것을 모음 조화(母音調和)라고 한다. 다음은 ‘-아’ 계열과 ‘-어’ 계열의 어미가 결합하는 양상을 보인 것이다. (2)
    1-3 원문: 시들을
        교정문: 시들
        수정 세부사항:
          - 어간 끝 받침 ‘ㄹ’이 ‘ㄴ, ㅂ, ㅅ’으로 시작하는 어미나 어미 ‘­-오, -­ㄹ’ 등 앞에서 나타나지 않으면 나타나지 않는 대로 적는다. 예를 들어 ‘살다’의 어간 ‘살-’에 어미 ‘-네, -세, -오’가 결합하면 ‘ㄹ’이 탈락하여 ‘사네, 사세, 사오’가 된다. 이를 도식화하여 보이면 다음과 같다.
‘갈다, 날다, 말다, 물다, 벌다, 불다, 알다, 울다, 졸다, 팔다’ 등 어간 끝 받침이 ‘ㄹ’인 용언은 모두 이에 해당한다. 위와 같은 환경에서는 ‘ㄹ’이 예외 없이 탈락하므로 다른 불규칙 활용과 차이가 있다. (2)
    1-4 원문: 꽃에물을
        교정문: 꽃에 물을
        수정 세부사항:
          - 문장의 각 단어는 띄어 씀을 원칙으로 한다. (3)
    1-5 원문: 고은
        교정문: 고운
        수정 세부사항:
          - ‘돕-, 곱-’과 같은 단음절 어간에 어미 ‘-아’가 결합되어 ‘와’로 소리 나는 것은 ‘-와’로 적는다. (2)

```