### PR TITLE
Fix  ca 인증서 오류 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,181 +1,217 @@
-# What is this?
+# bareunpy
 
-`bareunpy` is the python 3 library for bareun.
+**bareunpy**는 한국어 자연어 처리(NLP) 엔진 **[Bareun](https://bareun.ai/)** 의 Python 3 클라이언트 라이브러리입니다.
 
-Bareun is a Korean NLP,
-which provides tokenizing, POS tagging for Korean.
+형태소 분석(POS tagging), 토크나이징(tokenizing), 맞춤법 검사(spelling correction) 기능을 제공합니다.
 
-## How to install
+---
+
+## 설치 (Installation)
 
 ```shell
 pip3 install bareunpy
 ```
 
-## How to get bareun
-- Go to https://bareun.ai/.
-  - With registration, for the first time, you can get a API-KEY to use it freely.
-  - With API-KEY, you can install the `bareun1` server.
-  - Or you can make a call to use this `bareunpy` library to any servers.
-- Or use docker image. See https://hub.docker.com/r/bareunai/bareun
-```shell
-docker pull bareunai/bareun:latest
-```
+## API KEY 발급
 
-## How to use, tagger
+1. https://bareun.ai/ 에 접속하여 회원가입 후 이메일 인증을 완료하면 자동 발급됩니다.
+2. **로그인 → 내정보 확인**에서 API KEY(`koba-...`)를 조회합니다.
+
+> 발급받은 API KEY로 `api.bareun.ai` 호스팅 서버에 바로 연결하거나,
+> 자체 서버에 Bareun을 설치하여 사용할 수도 있습니다.
+
+## 서버 연결 방식
 
 ```python
-import sys
-import google.protobuf.text_format as tf
-from google.protobuf.json_format import MessageToDict
 from bareunpy import Tagger
 
-# You can get an API-KEY from https://bareun.ai/
-# Please note that you need to sign up and verify your email.
-# 아래에 "https://bareun.ai/"에서 이메일 인증 후 발급받은 API KEY("koba-...")를 입력해주세요. "로그인-내정보 확인"
-API_KEY = "koba-ABCDEFG-1234567-LMNOPQR-7654321" # <- 본인의 API KEY로 교체(Replace this with your own API KEY)
+API_KEY = "koba-ABCDEFG-1234567-LMNOPQR-7654321"  # 본인의 API KEY로 교체
 
-# If you have your own localhost bareun.
-tagger = Tagger(API_KEY, 'localhost')
-# or if you have your own bareun which is running on 10.8.3.211:15656.
-tagger = Tagger(API_KEY, '10.8.3.211', 15656)
-# If you don’t want to run your own Bareun server, you can use the official hosted endpoint.
-# Just provide your API key and point the client to `api.bareun.ai` on port `443`.
+# 1) 호스팅 API 사용 (가장 간편한 방법, host 생략 시 기본값)
+tagger = Tagger(API_KEY)
+# 또는 명시적으로 지정
 tagger = Tagger(API_KEY, 'api.bareun.ai', 443)
 
-# print results. 
-res = tagger.tags(["안녕하세요.", "반가워요!"])
+# 2) 로컬 서버 사용
+tagger = Tagger(API_KEY, 'localhost', 5656)
 
-# get protobuf message.
-m = res.msg()
-tf.PrintMessage(m, out=sys.stdout, as_utf8=True)
-print(tf.MessageToString(m, as_utf8=True))
-print(f'length of sentences is {len(m.sentences)}')
-## output : 2
-print(f'length of tokens in sentences[0] is {len(m.sentences[0].tokens)}')
-print(f'length of morphemes of first token in sentences[0] is {len(m.sentences[0].tokens[0].morphemes)}')
-print(f'lemma of first token in sentences[0] is {m.sentences[0].tokens[0].lemma}')
-print(f'first morph of first token in sentences[0] is {MessageToDict(m.sentences[0].tokens[0].morphemes[0])}')
-print(f'tag of first morph of first token in sentences[0] is {m.sentences[0].tokens[0].morphemes[0].tag}')
-
-## Advanced usage.
-for sent in m.sentences:
-    for token in sent.tokens:
-        for m in token.morphemes:
-            print(f'{m.text.content}/{m.tag}:{m.probability}:{m.out_of_vocab}')
-
-# get json object
-jo = res.as_json()
-print(jo)
-
-# get tuple of pos tagging.
-pa = res.pos()
-print(pa)
-# another methods
-ma = res.morphs()
-print(ma)
-na = res.nouns()
-print(na)
-va = res.verbs()
-print(va)
-
-# custom dictionary
-cust_dic = tagger.custom_dict("my")
-cust_dic.copy_np_set({'내고유명사', '우리집고유명사'})
-cust_dic.copy_cp_set({'코로나19'})
-cust_dic.copy_cp_caret_set({'코로나^백신', '"독감^백신'})
-cust_dic.update()
-
-# laod prev custom dict
-cust_dict2 = tagger.custom_dict("my")
-cust_dict2.load()
-
-tagger.set_domain('my')
-tagger.pos('코로나19는 언제 끝날까요?')
+# 3) 원격 자체 서버 사용 (예: 10.8.3.211:15656)
+tagger = Tagger(API_KEY, '10.8.3.211', 15656)
 ```
 
+> 자체 서버 설치는 Docker 이미지로 간편하게 할 수 있습니다.
+> ```shell
+> docker pull bareunai/bareun:latest
+> ```
+> 자세한 내용은 [Docker Hub](https://hub.docker.com/r/bareunai/bareun)를 참고하세요.
 
-## How to use, tokenizer
+---
+
+## 형태소 분석 (Tagger)
+
+### 기본 사용법
+
+```python
+from bareunpy import Tagger
+
+API_KEY = "koba-ABCDEFG-1234567-LMNOPQR-7654321"  # 본인의 API KEY로 교체
+tagger = Tagger(API_KEY)
+
+# POS 태깅
+print(tagger.pos('햇빛이 선명하게 나뭇잎을 핥고 있었다.'))
+# [('햇빛', 'NNG'), ('이', 'JKS'), ('선명', 'NNG'), ('하', 'XSA'), ('게', 'EC'),
+#  ('나뭇잎', 'NNG'), ('을', 'JKO'), ('핥', 'VV'), ('고', 'EC'), ('있', 'VX'),
+#  ('었', 'EP'), ('다', 'EF'), ('.', 'SF')]
+
+# 형태소 추출
+print(tagger.morphs('안녕하세요, 반가워요.'))
+# ['안녕', '하', '시', '어요', ',', '반갑', '어요', '.']
+
+# 명사 추출
+print(tagger.nouns('나비 허리에 새파란 초생달이 시리다.'))
+# ['나비', '허리', '초생달']
+
+# 동사 추출
+print(tagger.verbs('햇빛이 선명하게 나뭇잎을 핥고 있었다.'))
+# ['핥']
+```
+
+### 여러 문장 분석
+
+```python
+# tags(): 여러 문장을 한 번에 분석 (문장 분할 적용)
+res = tagger.tags(["안녕하세요.", "반가워요!"])
+
+# taglist(): 입력된 문장 단위를 그대로 유지하여 분석 (문장 분할 없음)
+res = tagger.taglist(["안녕하세요.", "반가워요!"])
+```
+
+### 분석 옵션
+
+`tag()`, `tags()`, `taglist()` 메서드에서 다음 옵션을 사용할 수 있습니다.
+
+| 파라미터 | 타입 | 기본값 | 설명 |
+|---|---|---|---|
+| `auto_split` | bool | `False` | 문장 자동 분리 (`tag`, `tags`만 해당) |
+| `auto_spacing` | bool | `True` | 띄어쓰기 보정 |
+| `auto_jointing` | bool | `True` | 붙여쓰기 보정 |
+
+```python
+res = tagger.tag('햇빛이선명하게나뭇잎을핥고있었다', auto_spacing=True, auto_jointing=True)
+print(res.pos())
+```
+
+### 결과 활용
+
+```python
+res = tagger.tags(["안녕하세요.", "반가워요!"])
+
+# protobuf 메시지 원본
+m = res.msg()
+
+# JSON 변환
+print(res.as_json())
+print(res.as_json_str())
+
+# 형태소, POS 태그, 명사, 동사 추출
+print(res.morphs())
+print(res.pos())
+print(res.nouns())
+print(res.verbs())
+```
+
+### 상세 결과 탐색 (Advanced)
 
 ```python
 import sys
 import google.protobuf.text_format as tf
-from google.protobuf.json_format import MessageToDict
-from bareunpy import Tokenizer
 
-# You can get an API-KEY from https://bareun.ai/
-# Please note that you need to sign up and verify your email.
-# 아래에 "https://bareun.ai/"에서 이메일 인증 후 발급받은 API KEY("koba-...")를 입력해주세요. "로그인-내정보 확인"
-API_KEY = "koba-ABCDEFG-1234567-LMNOPQR-7654321" # <- 본인의 API KEY로 교체(Replace this with your own API KEY)
-
-# If you have your own localhost bareun.
-tokenizer = Tokenizer(API_KEY, 'localhost')
-# or if you have your own bareun which is running on 10.8.3.211:15656.
-tokenizer = Tokenizer(API_KEY, '10.8.3.211', 15656)
-# If you don’t want to run your own Bareun server, you can use the official hosted endpoint.
-# Just provide your API key and point the client to `api.bareun.ai` on port `443`.
-tokenizer = Tokenizer(API_KEY, 'api.bareun.ai', 443)
-
-# print results. 
-tokenized = tokenizer.tokenize_list(["안녕하세요.", "반가워요!"])
-
-# get protobuf message.
-m = tokenized.msg()
+m = res.msg()
 tf.PrintMessage(m, out=sys.stdout, as_utf8=True)
-print(tf.MessageToString(m, as_utf8=True))
-print(f'length of sentences is {len(m.sentences)}')
-## output : 2
-print(f'length of tokens in sentences[0] is {len(m.sentences[0].tokens)}')
-print(f'length of segments of first token in sentences[0] is {len(m.sentences[0].tokens[0].segments)}')
-print(f'tagged of first token in sentences[0] is {m.sentences[0].tokens[0].tagged}')
-print(f'first segment of first token in sentences[0] is {MessageToDict(m.sentences[0].tokens[0].segments[0])}')
-print(f'hint of first morph of first token in sentences[0] is {m.sentences[0].tokens[0].segments[0].hint}')
 
-## Advanced usage.
 for sent in m.sentences:
     for token in sent.tokens:
-        for m in token.segments:
-            print(f'{m.text.content}/{m.hint}')
-
-# get json object
-jo = tokenized.as_json()
-print(jo)
-
-# get tuple of segments
-ss = tokenized.segments()
-print(ss)
-ns = tokenized.nouns()
-print(ns)
-vs = tokenized.verbs()
-print(vs)
-# postpositions: 조사
-ps = tokenized.postpositions()
-print(ps)
-# Adverbs, 부사
-ass = tokenized.adverbs()
-print(ass)
-ss = tokenized.symbols()
-print(ss)
-
+        for morph in token.morphemes:
+            print(f'{morph.text.content}/{morph.tag}:{morph.probability}:{morph.out_of_vocab}')
 ```
 
-## How to use, spelling corrector
+---
+
+## 토크나이저 (Tokenizer)
+
+```python
+from bareunpy import Tokenizer
+
+API_KEY = "koba-ABCDEFG-1234567-LMNOPQR-7654321"  # 본인의 API KEY로 교체
+tokenizer = Tokenizer(API_KEY)
+
+# 토크나이징
+tokenized = tokenizer.tokenize_list(["안녕하세요.", "반가워요!"])
+
+# 다양한 추출 메서드
+print(tokenized.segments())       # 전체 세그먼트
+print(tokenized.nouns())          # 명사
+print(tokenized.verbs())          # 동사
+print(tokenized.postpositions())  # 조사
+print(tokenized.adverbs())        # 부사
+print(tokenized.symbols())        # 기호
+```
+
+### 상세 결과 탐색
+
+```python
+m = tokenized.msg()
+for sent in m.sentences:
+    for token in sent.tokens:
+        for seg in token.segments:
+            print(f'{seg.text.content}/{seg.hint}')
+```
+
+---
+
+## 맞춤법 검사 (Corrector)
+
+> **참고:** 맞춤법 검사는 `api.bareun.ai` 호스팅 API에서만 사용 가능합니다. 로컬 서버에서는 지원되지 않습니다.
+
 ```python
 from bareunpy import Corrector
 
-# You can get an API-KEY from https://bareun.ai/
-# Please note that you need to sign up and verify your email.
-# 아래에 "https://bareun.ai/"에서 이메일 인증 후 발급받은 API KEY("koba-...")를 입력해주세요. "로그인-내정보 확인"
-API_KEY = "koba-ABCDEFG-1234567-LMNOPQR-7654321"  # <- 본인의 API KEY로 교체(Replace this with your own API KEY)
+API_KEY = "koba-ABCDEFG-1234567-LMNOPQR-7654321"  # 본인의 API KEY로 교체
+corrector = Corrector(API_KEY)
 
-# Initialize Corrector
-# The spelling corrector is available only via the hosted Bareun API.
-# There is no local server for Corrector. To use it, supply your API key and connect to:
-corrector = Corrector(API_KEY, 'api.bareun.ai', 443)
-
-# sentence correction
 response = corrector.correct_error("영수 도 줄기가 얇어서 시들을 것 같은 꽃에물을 주었다.")
-print(f"Original: {response.origin}")
-print(f"Corrected: {response.revised}")
-corrector.print_results(response)
+print(f"원문:   {response.origin}")
+print(f"교정문: {response.revised}")
 
+# 상세 결과 출력
+corrector.print_results(response)
+```
+
+---
+
+## 사용자 사전 (Custom Dictionary)
+
+사용자 사전을 등록하면 도메인 특화 용어의 분석 정확도를 높일 수 있습니다.
+
+### 사전 등록 및 업데이트
+
+```python
+# 사용자 사전 생성/수정
+cust_dic = tagger.custom_dict("my")
+cust_dic.copy_np_set({'내고유명사', '우리집고유명사'})    # 고유명사
+cust_dic.copy_cp_set({'코로나19'})                       # 복합명사
+cust_dic.copy_cp_caret_set({'코로나^백신', '독감^백신'})  # 복합명사 (분리 위치 지정)
+cust_dic.update()
+```
+
+### 사전 불러오기 및 적용
+
+```python
+# 기존 사전 불러오기
+cust_dic2 = tagger.custom_dict("my")
+cust_dic2.load()
+
+# 분석 시 사용자 사전 적용
+tagger.set_custom_dicts(["my"])
+tagger.pos('코로나19는 언제 끝날까요?')
 ```

--- a/bareunpy/_corrector.py
+++ b/bareunpy/_corrector.py
@@ -73,7 +73,7 @@ class Corrector:
 
         Args:
             content (str): 교정을 요청할 문장
-            custom_dicts (List[str]): 커스텀 도메인 정보
+            custom_dicts (List[str]): 사용자 사전의 이름 목록
             config Union[pb.RevisionConfig, None] : 요청 설정
 
         Returns:

--- a/bareunpy/_corrector.py
+++ b/bareunpy/_corrector.py
@@ -43,7 +43,7 @@ class Corrector:
     :param port: int. gRPC 서버 포트 (기본값: 5656)
     """
 
-    def __init__(self, apikey: str, host: str = "", port: int = 5656):
+    def __init__(self, apikey: str, host: str = "", port: int = None):
         """
         Corrector 초기화
 

--- a/bareunpy/_lang_service_client.py
+++ b/bareunpy/_lang_service_client.py
@@ -193,10 +193,10 @@ class BareunLanguageServiceClient:
 
         Args:
             content (str): 형태소 분석할 원문, 여러 문장일 경우에 개행문자로 줄바꿈을 하면 됩니다.
-            domain (str, optional): 사용사 사전의 이름. 기본값은 "".
+            custom_dicts (list, optional): 사용자 사전의 이름. 기본값은 [].
             auto_split (bool, optional): 문장 자동 분리 여부, 기본값은 사용하지 않음.
             auto_spacing (bool, optional): 띄어쓰기 보정 기능, 기본값은 사용하도록 함.
-            auto_jointing (bool, optional): 붙여쓰기 보정 기능, 기본값은 사용하지 않음.
+            auto_jointing (bool, optional): 붙여쓰기 보정 기능, 기본값은 사용하도록 함.
 
         Raises:
             e: grpc.Error, 원격 호출시 예외가 발생할 수 있습니다.
@@ -205,7 +205,6 @@ class BareunLanguageServiceClient:
             pb.AnalyzeSyntaxResponse: 형태소 분석 결과
         """
         req = pb.AnalyzeSyntaxRequest()
-        # req.document = pb.Document()
         req.document.content = content
         req.document.language = "ko_KR"
         req.encoding_type = lpb.EncodingType.UTF32
@@ -235,7 +234,7 @@ class BareunLanguageServiceClient:
 
         Args:
             content (List[str]): 형태소 분석할 원문의 리스트
-            domain (str, optional): 사용사 사전의 이름. 기본값은 "".
+            custom_dicts (list, optional): 사용자 사전의 이름. 기본값은 [].
             auto_spacing (bool, optional): 띄어쓰기 보정 기능, 기본값은 사용하도록 함.
             auto_jointing (bool, optional): 붙여쓰기 보정 기능, 기본값은 사용하지 않음.
 
@@ -271,7 +270,6 @@ class BareunLanguageServiceClient:
 
         Args:
             content (str): 형태소 분석할 원문, 여러 문장일 경우에 개행문자로 줄바꿈을 하면 됩니다.
-            domain (str, optional): 사용사 사전의 이름. 기본값은 "".
             auto_split (bool, optional): 문장 자동 분리 여부, 기본값은 사용하지 않음.
 
         Raises:

--- a/bareunpy/_lang_service_client.py
+++ b/bareunpy/_lang_service_client.py
@@ -1,4 +1,6 @@
 import grpc
+import ssl
+import logging
 from typing import List
 
 import bareunpy
@@ -7,74 +9,115 @@ import bareun.language_service_pb2_grpc as ls
 import bareun.lang_common_pb2 as lpb
 
 MAX_MESSAGE_LENGTH = 100 * 1024 * 1024
-CA_BUNDLE = b"""-----BEGIN CERTIFICATE-----
-MIIGEzCCA/ugAwIBAgIQfVtRJrR2uhHbdBYLvFMNpzANBgkqhkiG9w0BAQwFADCB
-iDELMAkGA1UEBhMCVVMxEzARBgNVBAgTCk5ldyBKZXJzZXkxFDASBgNVBAcTC0pl
-cnNleSBDaXR5MR4wHAYDVQQKExVUaGUgVVNFUlRSVVNUIE5ldHdvcmsxLjAsBgNV
-BAMTJVVTRVJUcnVzdCBSU0EgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkwHhcNMTgx
-MTAyMDAwMDAwWhcNMzAxMjMxMjM1OTU5WjCBjzELMAkGA1UEBhMCR0IxGzAZBgNV
-BAgTEkdyZWF0ZXIgTWFuY2hlc3RlcjEQMA4GA1UEBxMHU2FsZm9yZDEYMBYGA1UE
-ChMPU2VjdGlnbyBMaW1pdGVkMTcwNQYDVQQDEy5TZWN0aWdvIFJTQSBEb21haW4g
-VmFsaWRhdGlvbiBTZWN1cmUgU2VydmVyIENBMIIBIjANBgkqhkiG9w0BAQEFAAOC
-AQ8AMIIBCgKCAQEA1nMz1tc8INAA0hdFuNY+B6I/x0HuMjDJsGz99J/LEpgPLT+N
-TQEMgg8Xf2Iu6bhIefsWg06t1zIlk7cHv7lQP6lMw0Aq6Tn/2YHKHxYyQdqAJrkj
-eocgHuP/IJo8lURvh3UGkEC0MpMWCRAIIz7S3YcPb11RFGoKacVPAXJpz9OTTG0E
-oKMbgn6xmrntxZ7FN3ifmgg0+1YuWMQJDgZkW7w33PGfKGioVrCSo1yfu4iYCBsk
-Haswha6vsC6eep3BwEIc4gLw6uBK0u+QDrTBQBbwb4VCSmT3pDCg/r8uoydajotY
-uK3DGReEY+1vVv2Dy2A0xHS+5p3b4eTlygxfFQIDAQABo4IBbjCCAWowHwYDVR0j
-BBgwFoAUU3m/WqorSs9UgOHYm8Cd8rIDZsswHQYDVR0OBBYEFI2MXsRUrYrhd+mb
-+ZsF4bgBjWHhMA4GA1UdDwEB/wQEAwIBhjASBgNVHRMBAf8ECDAGAQH/AgEAMB0G
-A1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAbBgNVHSAEFDASMAYGBFUdIAAw
-CAYGZ4EMAQIBMFAGA1UdHwRJMEcwRaBDoEGGP2h0dHA6Ly9jcmwudXNlcnRydXN0
-LmNvbS9VU0VSVHJ1c3RSU0FDZXJ0aWZpY2F0aW9uQXV0aG9yaXR5LmNybDB2Bggr
-BgEFBQcBAQRqMGgwPwYIKwYBBQUHMAKGM2h0dHA6Ly9jcnQudXNlcnRydXN0LmNv
-bS9VU0VSVHJ1c3RSU0FBZGRUcnVzdENBLmNydDAlBggrBgEFBQcwAYYZaHR0cDov
-L29jc3AudXNlcnRydXN0LmNvbTANBgkqhkiG9w0BAQwFAAOCAgEAMr9hvQ5Iw0/H
-ukdN+Jx4GQHcEx2Ab/zDcLRSmjEzmldS+zGea6TvVKqJjUAXaPgREHzSyrHxVYbH
-7rM2kYb2OVG/Rr8PoLq0935JxCo2F57kaDl6r5ROVm+yezu/Coa9zcV3HAO4OLGi
-H19+24rcRki2aArPsrW04jTkZ6k4Zgle0rj8nSg6F0AnwnJOKf0hPHzPE/uWLMUx
-RP0T7dWbqWlod3zu4f+k+TY4CFM5ooQ0nBnzvg6s1SQ36yOoeNDT5++SR2RiOSLv
-xvcRviKFxmZEJCaOEDKNyJOuB56DPi/Z+fVGjmO+wea03KbNIaiGCpXZLoUmGv38
-sbZXQm2V0TP2ORQGgkE49Y9Y3IBbpNV9lXj9p5v//cWoaasm56ekBYdbqbe4oyAL
-l6lFhd2zi+WJN44pDfwGF/Y4QA5C5BIG+3vzxhFoYt/jmPQT2BVPi7Fp2RBgvGQq
-6jG35LWjOhSbJuMLe/0CjraZwTiXWTb2qHSihrZe68Zk6s+go/lunrotEbaGmAhY
-LcmsJWTyXnW0OMGuf1pGg+pRyrbxmRE1a6Vqe8YAsOf4vmSyrcjC8azjUeqkk+B5
-yOGBQMkKW+ESPMFgKuOXwIlCypTPRpgSabuY0MLTDXJLR27lk8QyKGOHQ+SwMj4K
-00u/I5sUKUErmgQfky3xxzlIPK1aEn8=
------END CERTIFICATE-----
------BEGIN CERTIFICATE-----
-MIIFgTCCBGmgAwIBAgIQOXJEOvkit1HX02wQ3TE1lTANBgkqhkiG9w0BAQwFADB7
-MQswCQYDVQQGEwJHQjEbMBkGA1UECAwSR3JlYXRlciBNYW5jaGVzdGVyMRAwDgYD
-VQQHDAdTYWxmb3JkMRowGAYDVQQKDBFDb21vZG8gQ0EgTGltaXRlZDEhMB8GA1UE
-AwwYQUFBIENlcnRpZmljYXRlIFNlcnZpY2VzMB4XDTE5MDMxMjAwMDAwMFoXDTI4
-MTIzMTIzNTk1OVowgYgxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpOZXcgSmVyc2V5
-MRQwEgYDVQQHEwtKZXJzZXkgQ2l0eTEeMBwGA1UEChMVVGhlIFVTRVJUUlVTVCBO
-ZXR3b3JrMS4wLAYDVQQDEyVVU0VSVHJ1c3QgUlNBIENlcnRpZmljYXRpb24gQXV0
-aG9yaXR5MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAgBJlFzYOw9sI
-s9CsVw127c0n00ytUINh4qogTQktZAnczomfzD2p7PbPwdzx07HWezcoEStH2jnG
-vDoZtF+mvX2do2NCtnbyqTsrkfjib9DsFiCQCT7i6HTJGLSR1GJk23+jBvGIGGqQ
-Ijy8/hPwhxR79uQfjtTkUcYRZ0YIUcuGFFQ/vDP+fmyc/xadGL1RjjWmp2bIcmfb
-IWax1Jt4A8BQOujM8Ny8nkz+rwWWNR9XWrf/zvk9tyy29lTdyOcSOk2uTIq3XJq0
-tyA9yn8iNK5+O2hmAUTnAU5GU5szYPeUvlM3kHND8zLDU+/bqv50TmnHa4xgk97E
-xwzf4TKuzJM7UXiVZ4vuPVb+DNBpDxsP8yUmazNt925H+nND5X4OpWaxKXwyhGNV
-icQNwZNUMBkTrNN9N6frXTpsNVzbQdcS2qlJC9/YgIoJk2KOtWbPJYjNhLixP6Q5
-D9kCnusSTJV882sFqV4Wg8y4Z+LoE53MW4LTTLPtW//e5XOsIzstAL81VXQJSdhJ
-WBp/kjbmUZIO8yZ9HE0XvMnsQybQv0FfQKlERPSZ51eHnlAfV1SoPv10Yy+xUGUJ
-5lhCLkMaTLTwJUdZ+gQek9QmRkpQgbLevni3/GcV4clXhB4PY9bpYrrWX1Uu6lzG
-KAgEJTm4Diup8kyXHAc/DVL17e8vgg8CAwEAAaOB8jCB7zAfBgNVHSMEGDAWgBSg
-EQojPpbxB+zirynvgqV/0DCktDAdBgNVHQ4EFgQUU3m/WqorSs9UgOHYm8Cd8rID
-ZsswDgYDVR0PAQH/BAQDAgGGMA8GA1UdEwEB/wQFMAMBAf8wEQYDVR0gBAowCDAG
-BgRVHSAAMEMGA1UdHwQ8MDowOKA2oDSGMmh0dHA6Ly9jcmwuY29tb2RvY2EuY29t
-L0FBQUNlcnRpZmljYXRlU2VydmljZXMuY3JsMDQGCCsGAQUFBwEBBCgwJjAkBggr
-BgEFBQcwAYYYaHR0cDovL29jc3AuY29tb2RvY2EuY29tMA0GCSqGSIb3DQEBDAUA
-A4IBAQAYh1HcdCE9nIrgJ7cz0C7M7PDmy14R3iJvm3WOnnL+5Nb+qh+cli3vA0p+
-rvSNb3I8QzvAP+u431yqqcau8vzY7qN7Q/aGNnwU4M309z/+3ri0ivCRlv79Q2R+
-/czSAaF9ffgZGclCKxO/WIu6pKJmBHaIkU4MiRTOok3JMrO66BQavHHxW/BBC5gA
-CiIDEOUMsfnNkjcZ7Tvx5Dq2+UUTJnWvu6rvP3t3O9LEApE9GQDTF1w52z97GA1F
-zZOFli9d31kWTz9RvdVFGD/tSo7oBmF0Ixa1DVBzJ0RHfxBdiSprhTEUxOipakyA
-vGp4z7h/jnZymQyd/teRCBaho1+V
------END CERTIFICATE-----
-"""
+
+_logger = logging.getLogger(__name__)
+
+# 서버가 intermediate 인증서를 체인에 포함하지 않는 경우를 대비하여
+# api.bareun.ai의 intermediate CA를 런타임에 가져와 캐싱합니다.
+_cached_root_certs = None
+
+
+def _fetch_intermediate_certs(host: str, port: int = 443) -> bytes:
+    """서버의 leaf 인증서에서 AIA 확장을 읽어 intermediate CA를 자동으로 가져옵니다.
+
+    서버가 full chain을 보내지 않는 경우, leaf cert의 Authority Information Access(AIA)
+    확장에 있는 CA Issuers URL을 따라가서 intermediate 인증서를 다운로드합니다.
+    """
+    try:
+        from cryptography import x509
+        from cryptography.hazmat.backends import default_backend
+        from cryptography.hazmat.primitives.serialization import Encoding
+        from cryptography.x509.oid import AuthorityInformationAccessOID
+        import urllib.request
+
+        # 검증 없이 서버의 leaf cert를 가져옴
+        pem = ssl.get_server_certificate((host, port))
+        cert = x509.load_pem_x509_certificate(pem.encode(), default_backend())
+
+        intermediates = b""
+        seen = set()
+        current_cert = cert
+
+        # AIA 체인을 따라가며 intermediate 인증서들을 수집 (최대 5단계)
+        for _ in range(5):
+            try:
+                aia = current_cert.extensions.get_extension_for_class(
+                    x509.AuthorityInformationAccess
+                )
+            except x509.ExtensionNotFound:
+                break
+
+            ca_url = None
+            for desc in aia.value:
+                if desc.access_method == AuthorityInformationAccessOID.CA_ISSUERS:
+                    ca_url = desc.access_location.value
+                    break
+            if not ca_url or ca_url in seen:
+                break
+            seen.add(ca_url)
+
+            try:
+                resp = urllib.request.urlopen(ca_url, timeout=10)
+                der_data = resp.read()
+            except Exception:
+                break
+
+            # DER → PEM 변환
+            try:
+                # DER 형식인지 확인
+                intermediate_cert = x509.load_der_x509_certificate(der_data, default_backend())
+            except Exception:
+                try:
+                    intermediate_cert = x509.load_pem_x509_certificate(der_data, default_backend())
+                except Exception:
+                    break
+
+            pem_bytes = intermediate_cert.public_bytes(encoding=Encoding.PEM)
+            intermediates += pem_bytes
+
+            # self-signed이면 루트 도달, 중지
+            if intermediate_cert.issuer == intermediate_cert.subject:
+                break
+            current_cert = intermediate_cert
+
+        return intermediates
+    except Exception as e:
+        _logger.debug("intermediate 인증서 자동 다운로드 실패: %s", e)
+        return b""
+
+
+def _get_root_certificates(host: str = "api.bareun.ai", port: int = 443) -> bytes:
+    """런타임에 최신 CA 인증서를 로드합니다.
+
+    1. certifi 패키지가 있으면 Mozilla CA 번들을 로드합니다.
+       없으면 gRPC 내장 루트 인증서를 사용합니다.
+    2. 서버가 intermediate 인증서를 체인에 포함하지 않는 경우를 대비하여
+       AIA 확장을 통해 intermediate CA를 자동으로 가져와 번들에 추가합니다.
+    결과는 모듈 수준에서 캐싱됩니다.
+    """
+    global _cached_root_certs
+    if _cached_root_certs is not None:
+        return _cached_root_certs
+
+    # 1) certifi 또는 gRPC 기본 CA 번들
+    root_certs = None
+    try:
+        import certifi
+        with open(certifi.where(), 'rb') as f:
+            root_certs = f.read()
+    except (ImportError, IOError):
+        pass
+
+    # 2) intermediate 인증서 자동 보충
+    intermediates = _fetch_intermediate_certs(host, port)
+    if intermediates:
+        if root_certs:
+            root_certs = root_certs + b"\n" + intermediates
+        else:
+            root_certs = intermediates
+
+    _cached_root_certs = root_certs
+    return _cached_root_certs
 
 class BareunLanguageServiceClient:
     """
@@ -97,14 +140,12 @@ class BareunLanguageServiceClient:
                 )
         self.host = host
         self.port = port
-        self.channel = self._create_secure_channel(host, port, ca_cert_pem=CA_BUNDLE)
+        self.channel = self._create_secure_channel(host, port)
         self.stub = ls.LanguageServiceStub(self.channel)
     
     def _create_secure_channel(self,
         host: str,
         port: int,
-        *,
-        ca_cert_pem: bytes = None
     ) -> grpc.Channel:
         """
         gRPC 보안 채널을 생성합니다.
@@ -114,7 +155,8 @@ class BareunLanguageServiceClient:
             ('grpc.max_receive_message_length', MAX_MESSAGE_LENGTH),
         ]
         if host.lower().startswith("api.bareun.ai"):
-            creds = grpc.ssl_channel_credentials(root_certificates=ca_cert_pem)
+            root_certs = _get_root_certificates(host, port)
+            creds = grpc.ssl_channel_credentials(root_certificates=root_certs)
             return grpc.secure_channel(f"{host}:{port}",
                                        creds,
                                        options=opts)

--- a/bareunpy/_lang_service_client.py
+++ b/bareunpy/_lang_service_client.py
@@ -136,7 +136,6 @@ class BareunLanguageServiceClient:
         self.apikey = apikey
         self.metadata=(
                 ('api-key', self.apikey),
-                ('user-agent', f'bareunpy/{bareunpy.version}')
                 )
         self.host = host
         self.port = port
@@ -153,6 +152,7 @@ class BareunLanguageServiceClient:
         opts=[
             ('grpc.max_send_message_length', MAX_MESSAGE_LENGTH),
             ('grpc.max_receive_message_length', MAX_MESSAGE_LENGTH),
+            ('grpc.primary_user_agent', f'bareunpy/{bareunpy.version}'),
         ]
         if host.lower().startswith("api.bareun.ai"):
             root_certs = _get_root_certificates(host, port)

--- a/bareunpy/_revision_service_client.py
+++ b/bareunpy/_revision_service_client.py
@@ -1,7 +1,7 @@
 import grpc
 import bareun.revision_service_pb2 as pb
 import bareun.revision_service_pb2_grpc as rs_grpc
-from bareunpy._lang_service_client import CA_BUNDLE
+from bareunpy._lang_service_client import _get_root_certificates
 
 MAX_MESSAGE_LENGTH = 100 * 1024 * 1024
 
@@ -23,7 +23,7 @@ class BareunRevisionServiceClient:
         self.apikey = apikey
         self.host = host
         self.port = port
-        self.channel = self._create_secure_channel(host, port, ca_cert_pem=CA_BUNDLE)
+        self.channel = self._create_secure_channel(host, port)
         self.metadata = [
             ('api-key', self.apikey),
             ('user-agent', 'bareun-revision-client'),
@@ -33,8 +33,6 @@ class BareunRevisionServiceClient:
     def _create_secure_channel(self,
             host: str,
             port: int,
-            *,
-            ca_cert_pem: bytes = None
         ) -> grpc.Channel:
             """
             gRPC 보안 채널을 생성합니다.
@@ -44,7 +42,8 @@ class BareunRevisionServiceClient:
                 ('grpc.max_receive_message_length', MAX_MESSAGE_LENGTH),
             ]
             if host.lower().startswith("api.bareun.ai"):
-                creds = grpc.ssl_channel_credentials(root_certificates=ca_cert_pem)
+                root_certs = _get_root_certificates(host, port)
+                creds = grpc.ssl_channel_credentials(root_certificates=root_certs)
                 return grpc.secure_channel(f"{host}:{port}",
                                         creds,
                                         options=opts)

--- a/bareunpy/_revision_service_client.py
+++ b/bareunpy/_revision_service_client.py
@@ -1,4 +1,5 @@
 import grpc
+import bareunpy
 import bareun.revision_service_pb2 as pb
 import bareun.revision_service_pb2_grpc as rs_grpc
 from bareunpy._lang_service_client import _get_root_certificates
@@ -26,7 +27,6 @@ class BareunRevisionServiceClient:
         self.channel = self._create_secure_channel(host, port)
         self.metadata = [
             ('api-key', self.apikey),
-            ('user-agent', 'bareun-revision-client'),
         ]
         self.stub = rs_grpc.RevisionServiceStub(self.channel)
 
@@ -40,6 +40,7 @@ class BareunRevisionServiceClient:
             opts=[
                 ('grpc.max_send_message_length', MAX_MESSAGE_LENGTH),
                 ('grpc.max_receive_message_length', MAX_MESSAGE_LENGTH),
+                ('grpc.primary_user_agent', f'bareunpy/{bareunpy.version}'),
             ]
             if host.lower().startswith("api.bareun.ai"):
                 root_certs = _get_root_certificates(host, port)

--- a/bareunpy/_tagger.py
+++ b/bareunpy/_tagger.py
@@ -159,7 +159,7 @@ class Tagger:
     :param custom_dicts : List[str]. custom dictionary names for analyzing request
     """
 
-    def __init__(self, apikey:str, host: str = "", port: int = 5656, custom_dicts: List[str] = []):
+    def __init__(self, apikey:str, host: str = "", port: int = None, custom_dicts: List[str] = []):
 
         if host:
             host = host.strip()

--- a/bareunpy/_tagger.py
+++ b/bareunpy/_tagger.py
@@ -197,8 +197,8 @@ class Tagger:
     @DeprecationWarning
     def set_domain(self, domain: str):
         """
-        Set domain of custom dict.
-        :param domain: domain name of custom dict
+        사용자 사전 이름을 추가합니다. (deprecated: set_custom_dicts 를 사용하세요)
+        :param domain: 사용자 사전 이름
         """
         if len(self.custom_dicts) == 0:
             self.custom_dicts = []
@@ -206,8 +206,8 @@ class Tagger:
 
     def set_custom_dicts(self, custom_dicts: List[str]):
         """
-        Set domain of custom dict.
-        :param domain: domain name of custom dict
+        사용자 사전 이름 목록을 설정합니다.
+        :param custom_dicts: 사용자 사전 이름 목록
         """
         if len(custom_dicts) > 0:
             self.custom_dicts = custom_dicts
@@ -222,7 +222,7 @@ class Tagger:
         if name in self.internal_custom_dicts:
             return self.internal_custom_dicts[name]
         else:
-            self.internal_custom_dicts[name] = CustomDict(self.apikey, name,  self.channel)
+            self.internal_custom_dicts[name] = CustomDict(self.apikey, name,  self.client.channel)
             return self.internal_custom_dicts[name]
 
     def tag(self, phrase: str, auto_split: bool = False, auto_spacing: bool = True, auto_jointing: bool = True) -> Tagged:
@@ -256,11 +256,10 @@ class Tagger:
 
     def taglist(self, phrase: List[str], auto_spacing: bool = True, auto_jointing: bool = True) -> Tagged:
         """
-        the array is not being split and the input value is being returned as-is.
-        :param phrase: array of string
-        :param auto_split(bool, optional): Whether to automatically perform sentence split
-        :param auto_spacing(bool, optional): Whether to automatically perform space insertion for typo correction
-        :param auto_jointing(bool, optional): Whether to automatically perform word joining for typo correction
+        문장 분할 없이 입력된 문장 단위 그대로 형태소 분석을 수행합니다.
+        :param phrase: 분석할 문장의 리스트
+        :param auto_spacing(bool, optional): 띄어쓰기 보정 기능 (기본값: True)
+        :param auto_jointing(bool, optional): 붙여쓰기 보정 기능 (기본값: True)
         :return: Tagged result instance
         """
         if len(phrase) == 0:

--- a/bareunpy/_tokenizer.py
+++ b/bareunpy/_tokenizer.py
@@ -193,7 +193,7 @@ class Tokenizer:
     :param port         : int. port  for bareun server
     """
 
-    def __init__(self, apikey:str, host: str = "", port: int = 5656):
+    def __init__(self, apikey:str, host: str = "", port: int = None):
 
         if host:
             host = host.strip()

--- a/bareunpy/_version.py
+++ b/bareunpy/_version.py
@@ -1,4 +1,4 @@
 
-version = "1.7.2"
+version = "1.7.3"
 bareun_version = "3.0.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bareunpy"
-version = "1.7.2"
+version = "1.7.3"
 description = "The bareun python library using grpc"
 authors = ["Gihyun YUN <gih2yun@baikal.ai>"]
 license = "BSD-3-Clause"
@@ -35,6 +35,7 @@ protobuf = "^3.19.6"
 googleapis-common-protos = "^1.56.0"
 bareun-apis = "^0.15.2"
 certifi = ">=2023.7.22"
+cryptography = ">=3.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^6.2.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ grpcio = "^1.53.2"
 protobuf = "^3.19.6"
 googleapis-common-protos = "^1.56.0"
 bareun-apis = "^0.15.2"
+certifi = ">=2023.7.22"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^6.2.2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ grpcio==1.53.2
 googleapis-common-protos==1.56.0
 protobuf>=3.19.6
 bareun-apis==0.15.2
+certifi>=2023.7.22
 setuptools~=60.5.0  # 
 pytest>=7.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ googleapis-common-protos==1.56.0
 protobuf>=3.19.6
 bareun-apis==0.15.2
 certifi>=2023.7.22
+cryptography>=3.0
 setuptools~=60.5.0  # 
 pytest>=7.2.1


### PR DESCRIPTION
# fix: CA 인증서 오류 수정 및 클라이언트 개선

## 요약

`api.bareun.ai:443` 접속 시 발생하는 SSL 인증서 검증 실패(`CERTIFICATE_VERIFY_FAILED`) 오류를 수정하고, 클라이언트 라이브러리의 안정성과 사용 편의성을 개선합니다.

## 배경

서버 SSL 인증서가 갱신되면서 중간 CA가 `Sectigo RSA Domain Validation Secure Server CA`에서 `Sectigo Public Server Authentication CA DV R36`으로 변경되었습니다. 기존 코드에 하드코딩된 CA 번들이 더 이상 유효하지 않아 사용자들이 접속 오류를 겪고 있었습니다.

추가로, 서버가 leaf 인증서만 전송하고 중간 인증서 체인을 포함하지 않아 단순 CA 번들 교체만으로는 해결되지 않는 문제가 있었습니다.

## 변경 사항

### 1. SSL 인증서 자동 갱신 (`_lang_service_client.py`)

- **하드코딩된 `CA_BUNDLE` 제거** — 약 60줄의 PEM 인증서 상수 삭제
- **`certifi` 기반 root CA 로딩** — 시스템/패키지의 최신 CA 번들 자동 사용
- **AIA(Authority Information Access) 체이싱 구현** — 서버가 leaf 인증서만 보내는 경우, leaf 인증서의 AIA 확장에서 중간 CA 다운로드 URL을 추출하여 자동으로 인증서 체인 완성 (최대 5단계)
- **인증서 캐싱** — 모듈 레벨 `_cached_root_certs`로 중복 다운로드 방지

### 2. `_revision_service_client.py` 업데이트

- `CA_BUNDLE` 직접 참조 제거, `_get_root_certificates()` 함수로 전환
- 채널 생성 로직을 `_lang_service_client.py`와 동일한 방식으로 통일

### 3. 포트 자동 결정 (`_tagger.py`, `_tokenizer.py`, `_corrector.py`)

- `Tagger`, `Tokenizer`, `Corrector`의 `port` 기본값을 `5656` → `None`으로 변경
- `_resolve_port()` 함수가 host 기반으로 자동 결정:
  - `api.bareun.ai` → `443`
  - 그 외 → `5656`
- 기존: `Tagger(KEY)` → port `5656`으로 잘못 연결
- 수정 후: `Tagger(KEY)` → port `443`으로 올바르게 연결

### 4. Docstring 및 버그 수정

- "사용사 사전" → "사용자 사전" 오타 수정 (`_lang_service_client.py`)
- "커스텀 도메인 정보" → "사용자 사전의 이름 목록" (`_corrector.py`)
- `set_domain()` docstring에 deprecated 안내 추가 (`_tagger.py`)
- `set_custom_dicts()` docstring "Set domain of custom dict" → 한국어로 수정 (`_tagger.py`)
- `taglist()` docstring에서 시그니처에 없는 `auto_split` 파라미터 설명 제거 (`_tagger.py`)
- **`custom_dict()` 메서드의 `self.channel` → `self.client.channel` 버그 수정** (`_tagger.py`)

### 5. README.md 전면 개편

- 기능별 섹션 분리 (Tagger / Tokenizer / Corrector / Custom Dictionary)
- 서버 연결 방식 3가지를 한 곳에 명확히 정리
- 분석 옵션(`auto_split`, `auto_spacing`, `auto_jointing`) 테이블 추가
- deprecated `set_domain()` → `set_custom_dicts()` 사용 예시로 변경
- 한국어/영어 혼용 기존 스타일 유지, 가독성 향상

### 6. 의존성 및 버전

- 버전: `1.7.2` → `1.7.3`
- 의존성 추가:
  - `certifi >= 2023.7.22` — 최신 root CA 번들
  - `cryptography >= 3.0` — AIA 확장 파싱용